### PR TITLE
feature/card alignment

### DIFF
--- a/generator/data/card_data_example.js
+++ b/generator/data/card_data_example.js
@@ -115,7 +115,7 @@ var card_data_example = [
             "bullet | magic missile, 2nd level (2 charges)",
             "bullet | magic missile, 3rd level (3 charges)",
             "fill | 3",
-            "boxes | 7 | 2.5"
+            "boxes | 7 | 2.5 | center"
         ],
         "tags": ["item", "wondrous-item", "magic"]
     },

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -141,10 +141,11 @@ function card_element_boxes(params, card_data, options) {
     var stroke = ' stroke="' + color + '"';
     var count = params[0] || 1;
     var size = params[1] || 3;
+    var elementStyle = params[2] ? 'style="text-align: ' + params[2] + ';"' : "";
     var style = 'style="width:' + size + 'em;height:' + size + 'em"';
 
     var result = "";
-    result += '<div class="card-element card-description-line">';
+    result += '<div class="card-element card-description-line" ' + elementStyle + '>';
     for (var i = 0; i < count; ++i) {
         result += '<svg class="card-box" height="100" width="100" viewbox="0 0 100 100" preserveaspectratio="none" xmlns="http://www.w3.org/2000/svg" ' + style + '>';
         result += '    <rect x="5" y="5" width="90" height="90" ' + fill + stroke + ' style="stroke-width:10">';


### PR DESCRIPTION
### Changelog
feature(#102): Adds a third option to boxes which allows them to be alternately aligned.
improvement(#102): Center aligns the example Wand of Magic Missiles card.

#### Help text
- `boxes` A line full of empty boxes. Useful for items with charges and actions with limited use.  Param 1: number of boxes. Param 2: size of a box (where 1.0 is the size of the letter 'e'). Param 3: alignment of the boxes (defaults to 'left').