### PR TITLE
READY FOR REVIEW/MERGE - Add support for Avery 5371 (and compatible) business cards

### DIFF
--- a/generator/css/card-size.css
+++ b/generator/css/card-size.css
@@ -37,6 +37,12 @@ page[size="Letter"] {
     height: 11.0in;
 }
 
+/* US letter area */
+page[size="Letter - Landscape"] {
+    width:  11.0in;
+    height: 8.5in;
+}
+
 page[size="25x35"] {
     width: 2.5in;
     height: 3.5in;
@@ -46,6 +52,16 @@ page[size="25x35"] {
 .card {
     width:2.5in;
     height:3.5in;
+}
+
+/* Business card size */
+.card-size-20x35 {
+    width:2.0in;
+    height:3.5in;
+}
+.card-size-20x35 .card-back-icon {
+    width: 0.8in;
+    height: 0.8in;
 }
 
 /* Bridge card size */

--- a/generator/generate.html
+++ b/generator/generate.html
@@ -92,6 +92,7 @@
                             <select class="form-control" id="page-size" data-option="page_size">
                                 <option value="A4" selected>A4</option>
                                 <option value="Letter">US letter</option>
+                                <option value="Letter - Landscape">US letter (landscape)</option>
                                 <option value="25x35">2.5&quot; x 3.5&quot;</option>
                             </select>
                         </div>
@@ -102,6 +103,7 @@
                             <select class="form-control" id="card-size" data-option="card_size">
                                 <option value="225x35">2.25&quot; x 3.5&quot; (Bridge)</option>
                                 <option value="25x35" selected>2.5&quot; x 3.5&quot; (Poker)</option>
+                                <option value="20x35">2.0&quot; x 3.5&quot; (Business)</option>
                                 <option value="35x50">3.5&quot; x 5.0&quot;</option>
                                 <option value="75x50">7.5&quot; x 5.0&quot;</option>
                             </select>
@@ -376,7 +378,7 @@
                         <li>Some RPG systems are protected by copyright. Even if some spell/item data is freely available, it does not mean you may redistribute cards containing such data.</li>
                         <li>If you find a bug or have a feature request, post them at the <a href="https://github.com/crobi/rpg-cards/issues">Github project site</a>.</li>
                         <li>
-                            The user interface consists of three columns: 
+                            The user interface consists of three columns:
                             <img alt="help" src="img/help/help.png" style="max-width:95%; display:block; padding: 5px; margin: 10px 0 10px 0; border: 1px solid #ebebeb; box-shadow: 0 0 5px #ebebeb;"/>
                             The left column contains the menu and global settings.
                             In the middle menu, you can select and edit individual cards.

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -347,7 +347,7 @@ function card_generate_back(data, options) {
 	{
 		background_style = 'style = "background-image: url(&quot;' + url + '&quot;); background-size: contain; background-position: center; background-repeat: no-repeat;"';
 	}
-	else 
+	else
 	{
 		background_style = card_generate_color_gradient_style(color, options);
     }
@@ -462,6 +462,7 @@ function card_pages_generate_style(options) {
         case "A4": size = "210mm 297mm"; break;
         case "A5": size = "A5 portrait"; break;
         case "Letter": size = "letter portrait"; break;
+        case "Letter - Landscape": size = "letter landscape"; break;
         case "25x35": size = "2.5in 3.5in"; break;
         default: size = "auto";
     }


### PR DESCRIPTION
- Adds a `Letter - Landscape` page size.
- Adds a 2.0 in × 3.5 in standard business card size.

When used together in a 2×5 layout, this should match up pretty well to [Avery's 5371](https://www.avery.com/templates/5371) printable business cards (or anything compatible with that layout). Using this with the appropriate product is a great way to print your own cards on heavy stock and make cutting easier.