### PR TITLE
Add card element for "Savage Worlds" stats

### DIFF
--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -233,6 +233,10 @@
 .card-stats {
     width: 100%
 }
+.card-stats-sw-derived {
+    margin-top: 0;
+    margin-bottom: 0;
+}
 
 .card-stats-header {
     text-align: center;

--- a/generator/data/card_data_example.js
+++ b/generator/data/card_data_example.js
@@ -159,5 +159,24 @@ var card_data_example = [
             "description | Scimitar | Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage"
         ],
         "tags": ["creature", "humanoid"]
+    },
+    {
+        "count": 1,
+        "color": "black",
+        "title": "Wolf",
+        "icon": "wolf-head",
+        "icon_back": "wolf-head",
+        "contents": [
+			"swstats| 8 | 6 | 4 | 6 | 8 | 8 | 5 | 6 | $2",
+			"rule",
+			"property | Skills: | Athletics d8, Fighting d8, Intimidation d8, Notice d6, Stealth d8",
+			"property | Edges: | Alertness",
+
+			"section | Special Abilities",
+			"property | Bite: | Str+d4.",
+			"property | Size −1: | The heads of these canines come to an average human’s waist, and they weigh about 60 pounds.",
+			"property | Speed: | d10 running die."
+        ],
+        "tags": ["creature"]
     }
 ]

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -240,6 +240,39 @@ function card_element_dndstats(params, card_data, options) {
     return result;
 }
 
+function card_element_swstats(params, card_data, options) {
+    var stats = [];
+    for (var i = 0; i < 9; ++i) {
+        stats[i] = params[i] || '-';
+    }
+
+    var result = "";
+    result += '<table class="card-stats">';
+    result += '    <tbody><tr>';
+    result += '      <th class="card-stats-header">Agility</th>';
+    result += '      <th class="card-stats-header">Smarts</th>';
+    result += '      <th class="card-stats-header">Spirit</th>';
+    result += '      <th class="card-stats-header">Strength</th>';
+    result += '      <th class="card-stats-header">Vigor</th>';
+    result += '    </tr>';
+    result += '    <tr>';
+    result += '      <td class="card-stats-cell">d' + stats[0] + '</td>';
+    result += '      <td class="card-stats-cell">d' + stats[1] + '</td>';
+    result += '      <td class="card-stats-cell">d' + stats[2] + '</td>';
+    result += '      <td class="card-stats-cell">d' + stats[3] + '</td>';
+    result += '      <td class="card-stats-cell">d' + stats[4] + '</td>';
+    result += '    </tr>';
+    result += '  </tbody>';
+    result += '</table>';
+    result += '<p class="card-stats-sw-derived">';
+    result += ' <b>Pace</b> ' + stats[5];
+    result += ' <b>Parry</b> ' + stats[6];
+    result += ' <b>Toughness</b> ' + stats[7];
+    result += stats[8] ? ' <b>Loot</b> ' + stats[8] : '';
+    result += '</p>';
+    return result;
+}
+
 function card_element_bullet(params, card_data, options) {
     var result = "";
     result += '<ul class="card-element card-bullet-line">';
@@ -275,6 +308,7 @@ var card_element_generators = {
     boxes: card_element_boxes,
     description: card_element_description,
     dndstats: card_element_dndstats,
+    swstats: card_element_swstats,
     text: card_element_text,
     center: card_element_center,
     justify: card_element_justify,


### PR DESCRIPTION
I opened the PR a while ago as crobi/rpg-cards#92 and as mephitrpg/rpg-cards#1.

This PR add a new card element for [Savage Worlds](https://en.wikipedia.org/wiki/Savage_Worlds):
- `swstats` _Savage Worlds_ stat and loot block.
     - `Param1` - Agility value
     - `Param2` - Smarts value
     - `Param3` - Spirit value
     - `Param4` - Strength value
     - `Param5` - Vigor value
     - `Param6` - Pace value
     - `Param7` - Parry value
     - `Param8` - Toughness value
     - `Param9` - Loot value

For example:
`swstats| 8 | 6 | 4 | 6 | 8 | 8 | 5 | 6 | $2`
Would produce something like:
```
Agility  Smarts   Spirit  Strength  Vigor
  d8       d6       d4      d6        d8
Pace 8 Parry 5 Toughness 6 Loot $2
```
![wolf](https://user-images.githubusercontent.com/22368040/126297315-46622a87-d395-4adf-b99f-14ea698605b0.png)

I could also add some documentation to https://github.com/crobi/rpg-cards/tree/gh-pages.