### PR TITLE
Change `subsection` to `section`

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,9 +170,9 @@ This is not a complete documentation, but some information that should help you 
             Param1: the text.
         </li>
         <li>
-            <code>subsection</code>
-            A subsection header, with a horizontal rule below the subsection name.
-            Param1: the subsection name.
+            <code>section</code>
+            A section header, with a horizontal rule below the section name.
+            Param1: the section name.
         </li>
         <li>
             <code>boxes</code>


### PR DESCRIPTION
Should fix #116.
Crobi mentioned that there is no `subsection` element and the
documentation should be updated.

Credit should go to @henrygab, as he initially opened a PR (#129) to fix this.
