### PR TITLE
new feature: element type "divider" = centered text with gray background

### DIFF
--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -212,6 +212,14 @@ function card_element_justify(params, card_data, options) {
     return result;
 }
 
+function card_element_divider(params, card_data, options) {
+    var result = "";
+    result += '<div class="card-element card-description-line" style="text-align: center; background-color: lightgray">';
+    result += '   <p class="card-p card-description-text">' + (params[0] || '&nbsp;') + '</p>';
+    result += '</div>';
+    return result;
+}
+
 function card_element_dndstats(params, card_data, options) {
     var stats = [10, 10, 10, 10, 10, 10];
     var mods = [0,0,0,0,0,0];
@@ -330,6 +338,7 @@ var card_element_generators = {
     text: card_element_text,
     center: card_element_center,
     justify: card_element_justify,
+    divider: card_element_divider,
     bullet: card_element_bullet,
     fill: card_element_fill,
     section: card_element_section,


### PR DESCRIPTION
Not sure if "divider" is a good name for this type of element.
What I wanted to achieve is a section that is typically used for "requires attunement" hints - similar to the original 5e cards from WotC's essential kit.
Here is an example:
![image](https://user-images.githubusercontent.com/6802880/178961331-49c92ee7-6dd2-4d61-b37e-e9a68f257877.png)
