### PR TITLE
Don't show card back preview if arrangement front only selected

### DIFF
--- a/generator/js/ui.js
+++ b/generator/js/ui.js
@@ -206,8 +206,11 @@ function ui_render_selected_card() {
     $('#preview-container').empty();
     if (card) {
         var front = card_generate_front(card, card_options);
-        var back = card_generate_back(card, card_options);
-        $('#preview-container').html(front + "\n" + back);
+        var back = '';
+        if (card_options.card_arrangement !== 'front_only') {
+            back = "\n" + card_generate_back(card, card_options);
+        }
+        $('#preview-container').html(front + back);
     }
     local_store_save();
 }


### PR DESCRIPTION
Small change to not show the back side preview if "front side only" arrangement is selected.