### PR TITLE
Deck management tab with top/up/down/bottom move

### DIFF
--- a/generator/index.html
+++ b/generator/index.html
@@ -82,20 +82,12 @@
                                         <button type="button" class="btn btn-info btn-block" id="button-help">Open Help</button>
                                     </div>
                                     <div class="col-sm-6">
-                                        <button type="button" class="btn btn-danger btn-block" id="button-clear">Delete all</button>
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <div class="col-sm-6">
-                                        <button type="button" class="btn btn-primary btn-block" id="button-load-sample">Load sample</button>
-                                    </div>
-                                    <div class="col-sm-6">
                                         <button type="button" class="btn btn-primary btn-block" id="button-load">Load from file</button>
                                     </div>
                                 </div>
                                 <div class="form-group">
                                     <div class="col-sm-6">
-                                        <button type="button" class="btn btn-primary btn-block" id="button-sort">Sort</button>
+                                        <button type="button" class="btn btn-primary btn-block" id="button-load-sample">Load sample</button>
                                     </div>
                                     <div class="col-sm-6">
                                         <button type="button" class="btn btn-primary btn-block" id="button-save" onclick="ui_save_file()">Save to file</button>
@@ -104,10 +96,9 @@
                                 </div>
                                 <div class="form-group">
                                     <div class="col-sm-6">
-                                        <button type="button" class="btn btn-primary btn-block" id="button-filter">Map/Filter</button>
                                     </div>
                                     <div class="col-sm-6">
-                                        
+                                        <button type="button" class="btn btn-danger btn-block" id="button-clear">Delete all</button>
                                     </div>
                                 </div>
                                 <!--<span class="help-block">Generated cards open in a new tab or window.</span>-->
@@ -115,6 +106,66 @@
                             <!-- /PANEL BODY -->
                         </div>
                       </div>
+                    </div>
+
+
+                    <div class="panel panel-default">
+                        <div class="panel-heading" role="tab" id="headingDeck">
+                            <h4 class="panel-title">
+                                <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDeck" aria-expanded="false" aria-controls="collapseDeck">
+                                    <!-- PANEL TITLE -->
+                                    Deck
+                                    <!-- /PANEL TITLE -->
+                                </a>
+                            </h4>
+                        </div>
+                        <div id="collapseDeck" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingDeck">
+                            <div class="panel-body">
+                                <!-- PANEL BODY -->
+                                <form role="form" class="form-horizontal">
+                                    <div class="form-group">
+                                        <label for="selected-card" class="col-sm-2 control-label">Deck</label>
+                                        <div class="col-sm-10">
+                                            <p class="form-control-static" id="total_card_count">Deck contains 0 cards.</p>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <div class="col-sm-2">
+                                            <label for="selected-card" class="control-label" style="width: 100%; margin-bottom: 1em;">Card</label>
+                                            <button type="button" class="btn btn-default btn-block btn-sm" title="Move to top" id="button-move-top">⏫</button>
+                                            <button type="button" class="btn btn-default btn-block btn-sm" title="Move up" id="button-move-up">🔼</button>
+                                            <button type="button" class="btn btn-default btn-block btn-sm" title="Move down" id="button-move-down">🔽</button>
+                                            <button type="button" class="btn btn-default btn-block btn-sm" title="Move to bottom" id="button-move-bottom">⏬</button>
+                                        </div>
+                                        <div class="col-sm-10">
+                                            <select class="form-control" id="selected-card" size="15"></select>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <div class="col-sm-6">
+                                            <button type="button" class="btn btn-primary btn-block" id="button-add-card">Add new card</button>
+                                        </div>
+                                        <div class="col-sm-6">
+                                            <button type="button" class="btn btn-primary btn-block" id="button-duplicate-card">Duplicate card</button>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <div class="col-sm-6">
+                                            <button type="button" class="btn btn-primary btn-block" id="button-sort">Sort</button>
+                                        </div>
+                                        <div class="col-sm-6">
+                                            <button type="button" class="btn btn-primary btn-block" id="button-filter">Map/Filter</button>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <div class="col-sm-6">
+                                            <button type="button" class="btn btn-danger btn-block" id="button-delete-card">Delete card</button>
+                                        </div>
+                                    </div>
+                                </form>
+                                <!-- /PANEL BODY -->
+                            </div>
+                        </div>
                     </div>
 
 
@@ -359,30 +410,6 @@
             <div class="col-md-12 col-lg-5">
                 <!--<h3>Card</h3>-->
                 <form class="form-horizontal" role="form">
-                    <div class="form-group">
-                        <label for="selected-card" class="col-sm-2 control-label">Deck</label>
-                        <div class="col-sm-10">
-                            <p class="form-control-static" id="total_card_count">Deck contains 0 cards.</p>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="selected-card" class="col-sm-2 control-label">Card</label>
-                        <div class="col-sm-10">
-                            <select class="form-control" id="selected-card"></select>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="col-sm-2 control-label"></label>
-                        <div class="col-sm-4">
-                            <button type="button" class="btn btn-danger btn-block" id="button-delete-card">Delete card</button>
-                        </div>
-                        <div class="col-sm-3">
-                            <button type="button" class="btn btn-primary btn-block" id="button-add-card">Add new card</button>
-                        </div>
-                        <div class="col-sm-3">
-                            <button type="button" class="btn btn-primary btn-block" id="button-duplicate-card">Duplicate card</button>
-                        </div>
-                    </div>
                     <div class="form-group">
                         <label for="card-title" class="col-sm-2 control-label">Name</label>
                         <div class="col-sm-10">

--- a/generator/js/ui.js
+++ b/generator/js/ui.js
@@ -99,6 +99,9 @@ function ui_add_cards(data) {
     ui_init_cards(data);
     card_data = card_data.concat(data);
     ui_update_card_list();
+    ui_select_card_by_index(0);
+
+    $("#collapseDeck").collapse('toggle');
 }
 
 function ui_add_new_card() {
@@ -126,7 +129,8 @@ function ui_select_card_by_index(index) {
 }
 
 function ui_selected_card_index() {
-    return parseInt($("#selected-card").val(), 10);
+    var idx = $("#selected-card").val();
+    return idx === null ? null : parseInt($("#selected-card").val(), 10);
 }
 
 function ui_selected_card() {
@@ -165,7 +169,7 @@ function ui_save_file() {
     a.href = url;
     var filename = prompt("Filename:", ui_save_file.filename);
     if (filename) {
-        a.download = filename 
+        a.download = filename
         ui_save_file.filename = filename;
         a.click();
     }
@@ -229,7 +233,7 @@ function ui_setup_color_selector() {
             .attr("data-color", val)
             .text(name));
     });
-    
+
     // Callbacks for when the user picks a color
     $('#default_color_selector').colorselector({
         callback: function (value, color, title) {
@@ -572,6 +576,40 @@ function ui_apply_default_icon_back() {
     ui_render_selected_card();
 }
 
+function ui_move_top() {
+    if (ui_selected_card_index() != null) {
+        card_data.unshift(card_data.splice(ui_selected_card_index(), 1)[0]);
+        ui_update_card_list();
+        ui_select_card_by_index(0);
+    }
+}
+
+function ui_move_bottom() {
+    if (ui_selected_card_index() !== null) {
+        card_data.push(card_data.splice(ui_selected_card_index(), 1)[0]);
+        ui_update_card_list();
+        ui_select_card_by_index(card_data.length - 1);
+    }
+}
+
+function ui_move_up() {
+    var idx = ui_selected_card_index();
+    if (idx !== null && idx > 0) {
+        [card_data[idx], card_data[idx - 1]] = [card_data[idx - 1], card_data[idx]];
+        ui_update_card_list();
+        ui_select_card_by_index(idx - 1);
+    }
+}
+
+function ui_move_down() {
+    var idx = ui_selected_card_index();
+    if (idx !== null && idx < card_data.length - 1) {
+        [card_data[idx], card_data[idx + 1]] = [card_data[idx + 1], card_data[idx]];
+        ui_update_card_list();
+        ui_select_card_by_index(idx + 1);
+    }
+}
+
 
 //Adding support for local store
 function local_store_save() {
@@ -675,6 +713,11 @@ $(document).ready(function () {
 
     $("#sort-execute").click(ui_sort_execute);
     $("#filter-execute").click(ui_filter_execute);
+
+    $("#button-move-top").click(ui_move_top);
+    $("#button-move-bottom").click(ui_move_bottom);
+    $("#button-move-up").click(ui_move_up);
+    $("#button-move-down").click(ui_move_down);
 
     ui_update_card_list();
 });


### PR DESCRIPTION
I often lack the option to reorder individual cards. To allow it and make moving through cards easier at the same time, I've moved the list of cards to a new tab on the left. There you can navigate through your cards and quickly move them up/down or to the top/bottom of the list.

Quite big change from the user perspective, not so much in code.

Please let me know what you think and if you want to merge it or not. If not, I will just maintain a fork for my own needs.

![image](https://user-images.githubusercontent.com/4042673/186534517-587bbda6-53f1-49d0-927a-c4f2ea3395f5.png)
