### PR TITLE
P2e - Second Update

### DIFF
--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -251,7 +251,7 @@
     width: 100%;
     height: 1.0mm;
     margin-top: 0;
-    margin-bottom: -0.5em;
+    margin-bottom: 0;
 }
 
 .card-box {

--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -294,6 +294,13 @@
     font-size: inherit;
 }
 
+.card-p2e-trait-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+}
+
 .card-p2e-trait {
     border-style: double;
     border-width: 2px;
@@ -306,7 +313,7 @@
     text-align: left;
     text-indent: 0em;
     display: inline-block;
-    margin: 0.1em 0;
+    margin: 0;
 }
 
 .card-p2e-trait-common {

--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -311,3 +311,13 @@
     background-color: #c45500;
     border-color: #d8c483;
 }
+
+.card-p2e-trait-alignment {
+    background-color: #576294;
+    border-color: #d8c483;
+}
+
+.card-p2e-trait-size {
+    background-color: #3A7B58;
+    border-color: #d8c483;
+}

--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -335,3 +335,12 @@
     background-color: #3A7B58;
     border-color: #d8c483;
 }
+
+.card-p2e-attribute-line {
+    color: black;
+}
+
+.card-p2e-attributes-text {
+    margin: 0;
+    font-size: 9.5px;
+}

--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -247,6 +247,13 @@
     margin-bottom: 0.3em;
 }
 
+.card-p2e-ruler {
+    width: 100%;
+    height: 1.0mm;
+    margin-top: 0;
+    margin-bottom: -0.5em;
+}
+
 .card-box {
     display: inline;
     height: 10mm;

--- a/generator/data/card_data_example.js
+++ b/generator/data/card_data_example.js
@@ -192,5 +192,38 @@ var card_data_example = [
         "icon_back": "pope-crown",
         "title_size": "13",
         "card_font_size": "9"
+    },
+    {
+      "count": 1,
+      "title": "(P2e) Giant Rat (Creature-1)",
+      "contents": [
+        "p2e_start_trait_section",
+        "p2e_trait | alignment | N",
+        "p2e_trait | size | Small",
+        "p2e_trait | common | Animal",
+        "p2e_end_trait_section",
+        "property | Perception | +5; Low-light vision, scent (imprecise) 30 feet",
+        "property | Skills | Acrobatics +5, Atlethics +2 (+4 climb/swim), Stealth +5",
+        "p2e_stats | +1 | +3 | +2 | -4 | +1 | -3 | 15 | +6 | +7 | +3 | 8",
+        "p2e_ruler",
+        "p2e_activity | Stride | 1 | 30 feet, Climb 10 feet ",
+        "fill | 1",
+        "p2e_activity | Melee | 1 | Jaws +7 (agile, finesse). Damage 1d6+1 piercing plus filth fever",
+        "fill | 1",
+        "property | Filth Fever| (disease) The sickened and unconscious conditions from filth fever don’t improve on their own until the disease is cured. Saving Throw DC 14 Fortitude.",
+        "bullet | Stage 1: carrier with no ill effect (1d4 hours)",
+        "bullet | Stage 2 sickened 1 (1 day)",
+        "bullet | Stage 3 sickened 1 and slowed 1 (1 day)",
+        "bullet | Stage 4 unconscious (1 day)",
+        "bullet | Stage 5 dead",
+        "",
+        "fill | 1"
+      ],
+      "tags": [],
+      "color": "Crimson",
+      "icon_back": "monster-grasp",
+      "icon": "rat",
+      "card_font_size": "9",
+      "title_size": "11"
     }
 ]

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -291,7 +291,7 @@ function card_element_dndstats(params, card_data, options) {
 }
 
 function card_element_start_p2e_trait() {
-    return '<div>';
+    return '<div class="card-p2e-trait-container">';
 }
 
 function card_element_end_p2e_trait() {

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -300,10 +300,10 @@ function card_element_p2e_stats(params, card_data, options) {
     result += card_element_p2e_ruler(params, card_data, options)
     result += '<div class="card-p2e-attribute-line">';
     result += '   <p class="card-p2e-attributes-text">';
-    result += '       <b>CA </b> ' + params[6] + '; <b>Fort</b> ' + params[7] + '; <b>Ref</b> ' + params[8] + '; <b>Vol</b> ' + params[9]
+    result += '       <b>AC </b> ' + params[6] + '; <b>Fort</b> ' + params[7] + '; <b>Ref</b> ' + params[8] + '; <b>Will</b> ' + params[9]
     result += '   </p>';
     result += '   <p class="card-p2e-attributes-text">';
-    result += '       <b>PG </b> ' + params[10]
+    result += '       <b>HP </b> ' + params[10]
     result += '   </p>';
     result += '</div>';
     return result;

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -290,6 +290,25 @@ function card_element_dndstats(params, card_data, options) {
     return result;
 }
 
+function card_element_p2e_stats(params, card_data, options) {
+    var result = "";
+    result += '<div class="card-p2e-attribute-line">';
+    result += '   <p class="card-p2e-attributes-text">';
+    result += '       <b>Str</b> ' + params[0] + ', <b>Dex</b> ' + params[1] + ', <b>Con</b> ' + params[2] + ', <b>Int</b> ' + params[3] + ', <b>Wis</b> ' + params[4] + ', <b>Cha</b> ' + params[5]
+    result += '   </p>';
+    result += '</div>';
+    result += card_element_p2e_ruler(params, card_data, options)
+    result += '<div class="card-p2e-attribute-line">';
+    result += '   <p class="card-p2e-attributes-text">';
+    result += '       <b>CA </b> ' + params[6] + '; <b>Fort</b> ' + params[7] + '; <b>Ref</b> ' + params[8] + '; <b>Vol</b> ' + params[9]
+    result += '   </p>';
+    result += '   <p class="card-p2e-attributes-text">';
+    result += '       <b>PG </b> ' + params[10]
+    result += '   </p>';
+    result += '</div>';
+    return result;
+}
+
 function card_element_start_p2e_trait() {
     return '<div class="card-p2e-trait-container">';
 }
@@ -308,6 +327,33 @@ function card_element_p2e_trait(params, card_data, options) {
     result += '</span>';
     return result;
 }
+
+function card_element_p2e_activity(params, card_data, options) {
+    var card_font_size_class = card_size_class(card_data, options);
+    
+    var activity_icon;
+    if (params[1] == '0') {
+        activity_icon = 'icon-p2e-free-action';
+    } else if (params[1] == '1') {
+        activity_icon = 'icon-p2e-1-action';
+    } else if (params[1] == '2') {
+        activity_icon = 'icon-p2e-2-actions';
+    } else if (params[1] == '3') {
+        activity_icon = 'icon-p2e-3-actions';
+    } else if (params[1] == 'R') {
+        activity_icon = 'icon-p2e-reaction';
+    } 
+
+    var result = "";
+    result += '<div class="card-element card-property-line' + card_font_size_class + '">';
+    result += '   <h4 class="card-property-name">' + params[0] + '</h4>';
+    result += '   <div class="card-inline-icon ' + activity_icon + '" style="display: inline-block; vertical-align: middle; height: 10px; min-height: 10px; width: 10px; background-color: black;"></div>';
+    result += '   <p class="card-p card-property-text">' + params[2] + '</p>';
+    result += '</div>';
+    return result;
+}
+
+
 
 function card_element_swstats(params, card_data, options) {
     var stats = [];
@@ -391,9 +437,11 @@ var card_element_generators = {
     boxes: card_element_boxes,
     description: card_element_description,
     dndstats: card_element_dndstats,
+    p2e_stats: card_element_p2e_stats,
     p2e_start_trait_section: card_element_start_p2e_trait,
     p2e_trait: card_element_p2e_trait,
     p2e_end_trait_section: card_element_end_p2e_trait,
+    p2e_activity: card_element_p2e_activity,
     swstats: card_element_swstats,
     text: card_element_text,
     center: card_element_center,

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -286,11 +286,11 @@ function card_element_end_p2e_trait() {
 }
 
 function card_element_p2e_trait(params, card_data, options) {
-    var card_font_size_class = card_size_class(card_data, options); // ?
-    var badge_rarity = ' card-p2e-trait-' + params[0];
+    var card_font_size_class = card_size_class(card_data, options);
+    var badge_type = ' card-p2e-trait-' + params[0];
 
     var result = "";
-    result += '<span class="card-p2e-trait' + badge_rarity + card_font_size_class + '">';
+    result += '<span class="card-p2e-trait' + badge_type + card_font_size_class + '">';
     result += params[1];
     result += '</span>';
     return result;

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -159,6 +159,19 @@ function card_element_ruler(params, card_data, options) {
     return result;
 }
 
+function card_element_p2e_ruler(params, card_data, options) {
+    var color = card_data_color_front(card_data, options);
+    var fill = 'fill="' + color + '"';
+    var stroke = 'stroke="' + color + '"';
+    var card_font_size_class = card_size_class(card_data, options);
+
+    var result = "";
+    result += '<svg class="card-p2e-ruler' + card_font_size_class + '" height="1" width="100" viewbox="0 0 100 5" preserveaspectratio="none" xmlns="http://www.w3.org/2000/svg">';
+    result += '    <polyline points="0,0 100,0.5 0,1" ' + fill + '></polyline>';
+    result += '</svg>';
+    return result;
+}
+
 function card_element_boxes(params, card_data, options) {
     var color = card_data_color_front(card_data, options);
     var fill = ' fill="none"';
@@ -373,6 +386,8 @@ var card_element_generators = {
     property: card_element_property,
     rule: card_element_ruler,
     ruler: card_element_ruler,
+    p2e_rule: card_element_p2e_ruler,
+    p2e_ruler: card_element_p2e_ruler,
     boxes: card_element_boxes,
     description: card_element_description,
     dndstats: card_element_dndstats,


### PR DESCRIPTION
Added more Pathfinder 2nd Edition related functionalities:

- You can now create Alignment (blue) and Size (green) trait badges, apart from Common (red) and Uncommon (orange) trait badges.
- Created a new "rule"/"ruler" card element for Pathfinder 2e: It is a straight thin line, similar to the one in the stat blocks on the books.
- Created "p2e_activity" card element: Works similar to "property" but it accepts an extra parameter to show how many actions the activity require.
- Created "p2e_stats" card element: Displays attributes (Str, Dex, Con, Int, Wis and Cha), saving throws (Fort, Ref and Will), Armor Class and Hit Points.
- Created an example card containing these changes (in progress).