### PR TITLE
Add pathfinder 2 (German) rare trait background color

### DIFF
--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -326,6 +326,11 @@
     border-color: #d8c483;
 }
 
+.card-p2e-trait-rare {
+    background-color: #022661;
+    border-color: #d8c483;
+}
+
 .card-p2e-trait-alignment {
     background-color: #576294;
     border-color: #d8c483;


### PR DESCRIPTION
In German PF2 advanced players guide the "rare" category is dark blue, like here:

![Untitled](https://github.com/user-attachments/assets/f7d25ea9-21ae-4014-942a-44466a81bdb7)


This PR adds this "rare" trait color option. 