### PR TITLE
fix: use card_data.color for rendering if no color_front or color_back is defined

### DIFF
--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -68,11 +68,11 @@ function card_remove_tag(card, tag) {
 // ============================================================================
 
 function card_data_color_front(card_data, options) {
-    return card_data.color_front || options.default_color || "black";
+    return card_data.color_front || card_data.color || options.default_color || "black";
 }
 
 function card_data_color_back(card_data, options) {
-    return card_data.color_back || options.default_color || "black";
+    return card_data.color_back || card_data.color || options.default_color || "black";
 }
 
 function card_data_icon_front(card_data, options) {


### PR DESCRIPTION
This PR is a quickfix for https://github.com/crobi/rpg-cards/issues/198
