### PR TITLE
"card type" feature to display P2E style right aligned additional header text like "CREATURE 3", "ARKAN 1", "FEAT 1", etc.

### DIFF
--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -112,6 +112,7 @@
     font-weight: bold;
     background-color: inherit;
     color: white;
+    white-space: nowrap;
 }
 .card-title-16 {
     font-size: 16pt;

--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -99,15 +99,9 @@
 .card-type  {
     display: flex;
     justify-content: flex-end;
-    background-color: inherit;
-    color: white;
-    height: 8mm;
     width: 100%;
-    font-family: Lora, 'Calisto MT', 'Bookman Old Style', Bookman, 'Goudy Old Style', Garamond, 'Hoefler Text', 'Bitstream Charter', Georgia, serif;
-    font-variant: small-caps;
-    font-weight: bold;
-    font-size: 10pt;
-    line-height: 7.5mm;
+    padding-left: 0 !important;
+    margin-left: -20mm; /* allow some overlapping */
 }
 
 .card-title {

--- a/generator/css/cards.css
+++ b/generator/css/cards.css
@@ -96,6 +96,20 @@
     padding: 1mm 0 1mm 1mm;
 }
 
+.card-type  {
+    display: flex;
+    justify-content: flex-end;
+    background-color: inherit;
+    color: white;
+    height: 8mm;
+    width: 100%;
+    font-family: Lora, 'Calisto MT', 'Bookman Old Style', Bookman, 'Goudy Old Style', Garamond, 'Hoefler Text', 'Bitstream Charter', Georgia, serif;
+    font-variant: small-caps;
+    font-weight: bold;
+    font-size: 10pt;
+    line-height: 7.5mm;
+}
+
 .card-title {
     height: 8mm;
     padding-left: 2mm;

--- a/generator/index.html
+++ b/generator/index.html
@@ -481,6 +481,12 @@
                         </div>
                     </div>
                     <div class="form-group">
+                        <label for="card-type" class="col-sm-2 control-label">Type</label>
+                        <div class="col-sm-10">
+                            <input type="text" id="card-type" data-property="card_type" class="form-control" placeholder="Type">
+                        </div>
+                    </div>
+                    <div class="form-group">
                         <label for="card-title-size" class="col-sm-2 control-label">Title font size</label>
                         <div class="col-sm-10">
                             <select class="form-control" id="card-title-size" data-property="title_size">

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -110,7 +110,7 @@ function card_element_title(card_data, options) {
 
 function card_element_type(card_data, options) {
     var type = card_data.card_type || "";
-    return type ? '<div class="card-type">' + type + '</div>' : '';
+    return type ? '<div class="card-type card-title card-title-10">' + type + '</div>' : '';
 }
 
 function card_element_icon(card_data, options) {

--- a/generator/js/cards.js
+++ b/generator/js/cards.js
@@ -24,6 +24,7 @@ function card_default_options() {
         back_bleed: "2mm,2mm",
         back_bleed_width: "2mm",
         back_bleed_height: "2mm",
+        card_type: ""
     };
 }
 
@@ -105,6 +106,11 @@ function card_element_title(card_data, options) {
     var title = card_data.title || "";
     var title_size = card_data.title_size || options.default_title_size || 'normal';
     return '<div class="card-title card-title-' + title_size + '">' + title + '</div>';
+}
+
+function card_element_type(card_data, options) {
+    var type = card_data.card_type || "";
+    return type ? '<div class="card-type">' + type + '</div>' : '';
 }
 
 function card_element_icon(card_data, options) {
@@ -571,6 +577,7 @@ function card_generate_front(data, options) {
     result += '<div class="card ' + (options.rounded_corners ? 'rounded-corners' : '') + '" ' + card_style + '>';
     result += '<div class="card-header">';
     result += card_element_title(data, options);
+    result += card_element_type(data, options);
     result += card_element_icon(data, options);
     result += '</div>';
     result += card_generate_contents(data.contents, data, options);

--- a/generator/js/ui.js
+++ b/generator/js/ui.js
@@ -178,6 +178,7 @@ function ui_update_selected_card() {
     var card = ui_selected_card();
     if (card) {
         $("#card-title").val(card.title);
+        $("#card-type").val(card.card_type);
         $("#card-title-size").val(card.title_size);
         $("#card-font-size").val(card.card_font_size);
         $("#card-count").val(card.count);
@@ -189,6 +190,7 @@ function ui_update_selected_card() {
         $("#card-color").val(card.color).change();
     } else {
         $("#card-title").val("");
+        $("#card-type").val("");
         $("#card-title-size").val("");
         $("#card-font-size").val("");
         $("#card-count").val(1);
@@ -690,6 +692,7 @@ $(document).ready(function () {
     $("#selected-card").change(ui_update_selected_card);
 
     $("#card-title").change(ui_change_card_title);
+    $("#card-type").change(ui_change_card_property);
     $("#card-title-size").change(ui_change_card_property);
     $("#card-font-size").change(ui_change_card_property);
     $("#card-icon").change(ui_change_card_property);


### PR DESCRIPTION
This PR:
- adds a new card property "card_type"
- adds a new input field "Type"
- renders the card type as right aligned header text with title font size 10

Example:
![Screenshot 2025-04-08 at 13 23 58](https://github.com/user-attachments/assets/9bc4618b-2eb2-4b34-b117-f93f3328700f)

![Screenshot 2025-04-08 at 13 23 41](https://github.com/user-attachments/assets/ccba2024-4c95-432d-a511-3e5ec94df1b1)
